### PR TITLE
Adds 'Region' column back into mlab sites csv

### DIFF
--- a/dataflow/data/bigquery/mlab-sites/M-Lab Sites - Sites.csv
+++ b/dataflow/data/bigquery/mlab-sites/M-Lab Sites - Sites.csv
@@ -1,94 +1,94 @@
-Site,Country,State,City,Host,In service,Retired,Machine IPv4 prefix,Machine IPv6 prefix,Type of IPv6 connectivity,Transit provider
-ACC01,GH,,Accra,Ghana IXP,12/3/2014,8/1/2015,196.201.2.192/26,,,Ghana IXP
-ACC02,GH,,Accra,Ghana IXP,11/17/2014,,196.49.14.192/26,,,Ghana IXP
-AKL01,NZ,,Auckland,REANNZ,1/2/2013,,163.7.129.0/26,2404:138:4009::/64,native,REANNZ
-AMS01,NL,,Amsterdam,Google,07/09/09,,213.244.128.128/26,2001:4C08:2003:2::/64 ,native,Level3
-AMS02,NL,,Amsterdam,"Internap (Voxel.Net, Inc.)",07/23/09,,72.26.217.64/26,2001:48c8:7::/64,,Voxel
-ARN01,SE,,Stockholm,Google,,,213.248.112.64/26,2001:2030:0000:001B::/64,native,Telia
-ATH01,GR,,Athens,EETT/GRnet,08/10/09,7/6/2016,83.212.4.0/26,2001:648:2ffc:2101::/64,native,GRNET
-ATH02,GR,,Athens,EETT/GRnet,07/11/11,7/6/2016,83.212.5.128/26,2001:648:2ffc:2102::/64,native,GRNET
-ATL01,US,GA,Atlanta,Google,05/04/09,,4.71.254.128/26,2001:1900:3001:C::/64,native,Level3
-ATL02,US,GA,Atlanta,Equinix,06/17/16,,38.112.151.64/26,2001:550:5B00:1::/64,native,Cogent
-ATL03,US,GA,Atlanta,Equinix,09/25/14,,64.86.200.192/26,2001:5a0:3b02::/64,native,Tata
-ATL04,US,GA,Atlanta,Equinix,09/25/14,,173.205.0.192/26,2001:0668:001F:001C::/64,native,GTT
-ATL05,US,GA,Atlanta,Equinix,01/01/16,,67.106.215.192/26,2610:0018:0111:C002::/64,native,XO
-BEG01,RS,,Belgrade,Serbian Open eXchange,06/13/14,,188.120.127.0/26,2001:7f8:1e:6::/64,native,Serbian Open eXchange
-BKK01,TH,,Bangkok,CAT Telecom,1/28/2015,,61.7.252.0/26,2001:c38:902f::/64,,CAT Telecom
-BOG01,CO,,Bogota,RENATA,05/20/14,,190.15.11.0/26,,,Telefonica
-DEN01,US,CO,Denver,Equinix,11/06/14,,184.105.23.64/26,2001:470:1:250::/64,native,GTT
-DEN02,US,CO,Denver,Equinix,08/01/15,,4.34.58.0/26,2001:1900:2200:49::/64,,Level3
-DEN03,US,CO,Denver,Equinix,01/01/16,,65.46.46.128/26,2610:0018:010e:8003::/64,native,XO
-DEN04,US,CO,Denver,Equinix,11/06/14,,128.177.109.64/26,2001:438:fffd:2c::/64,native,Zayo
-DFW01,US,TX,Dallas,Google,07/08/09,,38.107.216.0/26,2001:550:2000::/64,native,Cogent
-DFW02,US,TX,Dallas,Equinix,09/25/14,,64.86.132.64/26,2001:5a0:3f00::/64,native,Tata
-DFW03,US,TX,Dallas,Equinix,01/05/15,,4.15.35.128/26,2001:1900:2200:44::/64,native,Level3
-DFW04,US,TX,Dallas,Equinix,01/01/16,,208.177.76.64/26,2610:0018:010E:0002::64,native,XO
-DFW05,US,TX,Dallas,Equinix,10/01/14,,128.177.163.64/26,2001:438:fffd:30::/64,native,Zayo
-DUB01,IE,,Dublin,HEAnet,,, 193.1.12.192/26,2001:770:B5::/64,,HEanet
-HAM01,DE,,Hamburg,Google,10/19/09,,80.239.142.192/26,2001:2030:0000:0019::/64,native,Telia
-HND01,JP,,Tokyo,WIDE,11/28/2011,,203.178.130.192/26,2001:200:0:b801::/64,native,WIDE
-IAD01,US,VA,Reston,Google,10/12/11,,216.156.197.128/26,2610:18:111:8001::/64,native,XO
-IAD02,US,VA,Ashburn,Equinix,09/01/14,,38.90.140.128/26,2001:550:200:7::/64,native,Cogent
-IAD03,US,VA,Ashburn,Equinix,11/17/14,,66.198.10.128/26,2001:5a0:3c03::/64,native,Tata
-IAD04,US,VA,Ashburn,Equinix,09/25/14,,173.205.4.0/26,2001:0668:001F:0021::/64,native,GTT
-IAD05,US,VA,Ashburn,Equinix,12/17/14,,4.35.238.192/26,2001:1900:2200:46::/64,native,Level3
-JNB01,ZA,,Johannesburg,Tenet,2/11/2013,,196.24.45.128/26,2001:4200:fff0:4512::/64,native,Tenet
-LAX01,US,CA,Los Angeles,Google,05/14/09,,38.98.51.0/26,2001:550:6800::/64 ,native,Cogent
-LAX02,US,CA,Los Angeles,Equinix,11/10/14,,63.243.240.64/26,2001:550:A600::/64,native,Tata
-LAX03,US,CA,Los Angeles,Equinix,09/25/14,,173.205.3.64/26,2001:0668:001F:001E::/64,native,GTT
-LAX04,US,CA,Los Angeles,Equinix,12/17/14,,4.15.166.0/26,2001:1900:2100:15::/64,native,Level3
-LAX05,US,CA,Los Angeles,Equinix,09/25/14,,128.177.109.192/26,2001:438:fffd:2e::/64,native,Zayo
-LBA01,UK,,Leeds,aql,08/03/12,,109.239.110.0/26,2a00:1a80:1:8::/64,,aql
-LCA01,CY,,Nicosia,OCECPR,02/20/13,,82.116.199.0/26 ,,,CyNet
+Site,Country,State,City,Host,In service,Retired,Machine IPv4 prefix,Machine IPv6 prefix,Type of IPv6 connectivity,Transit provider,Region,Site
+ACC01,GH,,Accra,Ghana IXP,12/3/2014,8/1/2015,196.201.2.192/26,,,Ghana IXP,Africa,ACC01
+ACC02,GH,,Accra,Ghana IXP,11/17/2014,,196.49.14.192/26,,,Ghana IXP,Africa,ACC02
+AKL01,NZ,,Auckland,REANNZ,1/2/2013,,163.7.129.0/26,2404:138:4009::/64,native,REANNZ,Oceania,AKL01
+AMS01,NL,,Amsterdam,Google,07/09/09,,213.244.128.128/26,2001:4C08:2003:2::/64 ,native,Level3,Europe,AMS01
+AMS02,NL,,Amsterdam,"Internap (Voxel.Net, Inc.)",07/23/09,,72.26.217.64/26,2001:48c8:7::/64,,Voxel,Europe,AMS02
+ARN01,SE,,Stockholm,Google,,,213.248.112.64/26,2001:2030:0000:001B::/64,native,Telia,Europe,ARN01
+ATH01,GR,,Athens,EETT/GRnet,08/10/09,7/6/2016,83.212.4.0/26,2001:648:2ffc:2101::/64,native,GRNET,Europe,ATH01
+ATH02,GR,,Athens,EETT/GRnet,07/11/11,7/6/2016,83.212.5.128/26,2001:648:2ffc:2102::/64,native,GRNET,Europe,ATH02
+ATL01,US,GA,Atlanta,Google,05/04/09,,4.71.254.128/26,2001:1900:3001:C::/64,native,Level3,North America,ATL01
+ATL02,US,GA,Atlanta,Equinix,06/17/16,,38.112.151.64/26,2001:550:5B00:1::/64,native,Cogent,North America,ATL02
+ATL03,US,GA,Atlanta,Equinix,09/25/14,,64.86.200.192/26,2001:5a0:3b02::/64,native,Tata,North America,ATL03
+ATL04,US,GA,Atlanta,Equinix,09/25/14,,173.205.0.192/26,2001:0668:001F:001C::/64,native,GTT,North America,ATL04
+ATL05,US,GA,Atlanta,Equinix,01/01/16,,67.106.215.192/26,2610:0018:0111:C002::/64,native,XO,North America,ATL05
+BEG01,RS,,Belgrade,Serbian Open eXchange,06/13/14,,188.120.127.0/26,2001:7f8:1e:6::/64,native,Serbian Open eXchange,Europe,BEG01
+BKK01,TH,,Bangkok,CAT Telecom,1/28/2015,,61.7.252.0/26,2001:c38:902f::/64,,CAT Telecom,Asia,BKK01
+BOG01,CO,,Bogota,RENATA,05/20/14,,190.15.11.0/26,,,Telefonica,South America,BOG01
+DEN01,US,CO,Denver,Equinix,11/06/14,,184.105.23.64/26,2001:470:1:250::/64,native,GTT,North America,DEN01
+DEN02,US,CO,Denver,Equinix,08/01/15,,4.34.58.0/26,2001:1900:2200:49::/64,,Level3,North America,DEN02
+DEN03,US,CO,Denver,Equinix,01/01/16,,65.46.46.128/26,2610:0018:010e:8003::/64,native,XO,North America,DEN03
+DEN04,US,CO,Denver,Equinix,11/06/14,,128.177.109.64/26,2001:438:fffd:2c::/64,native,Zayo,North America,DEN04
+DFW01,US,TX,Dallas,Google,07/08/09,,38.107.216.0/26,2001:550:2000::/64,native,Cogent,North America,DFW01
+DFW02,US,TX,Dallas,Equinix,09/25/14,,64.86.132.64/26,2001:5a0:3f00::/64,native,Tata,North America,DFW02
+DFW03,US,TX,Dallas,Equinix,01/05/15,,4.15.35.128/26,2001:1900:2200:44::/64,native,Level3,North America,DFW03
+DFW04,US,TX,Dallas,Equinix,01/01/16,,208.177.76.64/26,2610:0018:010E:0002::64,native,XO,North America,DFW04
+DFW05,US,TX,Dallas,Equinix,10/01/14,,128.177.163.64/26,2001:438:fffd:30::/64,native,Zayo,North America,DFW05
+DUB01,IE,,Dublin,HEAnet,,, 193.1.12.192/26,2001:770:B5::/64,,HEanet,Europe,DUB01
+HAM01,DE,,Hamburg,Google,10/19/09,,80.239.142.192/26,2001:2030:0000:0019::/64,native,Telia,Europe,HAM01
+HND01,JP,,Tokyo,WIDE,11/28/2011,,203.178.130.192/26,2001:200:0:b801::/64,native,WIDE,Asia,HND01
+IAD01,US,VA,Reston,Google,10/12/11,,216.156.197.128/26,2610:18:111:8001::/64,native,XO,North America,IAD01
+IAD02,US,VA,Ashburn,Equinix,09/01/14,,38.90.140.128/26,2001:550:200:7::/64,native,Cogent,North America,IAD02
+IAD03,US,VA,Ashburn,Equinix,11/17/14,,66.198.10.128/26,2001:5a0:3c03::/64,native,Tata,North America,IAD03
+IAD04,US,VA,Ashburn,Equinix,09/25/14,,173.205.4.0/26,2001:0668:001F:0021::/64,native,GTT,North America,IAD04
+IAD05,US,VA,Ashburn,Equinix,12/17/14,,4.35.238.192/26,2001:1900:2200:46::/64,native,Level3,North America,IAD05
+JNB01,ZA,,Johannesburg,Tenet,2/11/2013,,196.24.45.128/26,2001:4200:fff0:4512::/64,native,Tenet,Africa,JNB01
+LAX01,US,CA,Los Angeles,Google,05/14/09,,38.98.51.0/26,2001:550:6800::/64 ,native,Cogent,North America,LAX01
+LAX02,US,CA,Los Angeles,Equinix,11/10/14,,63.243.240.64/26,2001:550:A600::/64,native,Tata,North America,LAX02
+LAX03,US,CA,Los Angeles,Equinix,09/25/14,,173.205.3.64/26,2001:0668:001F:001E::/64,native,GTT,North America,LAX03
+LAX04,US,CA,Los Angeles,Equinix,12/17/14,,4.15.166.0/26,2001:1900:2100:15::/64,native,Level3,North America,LAX04
+LAX05,US,CA,Los Angeles,Equinix,09/25/14,,128.177.109.192/26,2001:438:fffd:2e::/64,native,Zayo,North America,LAX05
+LBA01,UK,,Leeds,aql,08/03/12,,109.239.110.0/26,2a00:1a80:1:8::/64,,aql,Europe,LBA01
+LCA01,CY,,Nicosia,OCECPR,02/20/13,,82.116.199.0/26 ,,,CyNet,Europe,LCA01
 LGA01,US,NY,New York,"Voxel
-Internap",02/10/09,04/21/16,74.63.50.0/26,2001:48c8:5:f::/64,,Voxel
-LGA02,US,NY,New York,Google,06/08/09,,38.106.70.128/26, 2001:550:1D00:100::/64 ,native,Cogent
-LGA03,US,NY,New York,Equinix,05/05/15,,64.86.148.128/26,2001:5a0:4300::/64,native,Tata
-LGA04,US,NY,New York,Equinix,09/25/14,,173.205.4.64/26,2001:0668:001F:0022::/64,native,GTT
-LGA05,US,NY,New York,Equinix,11/14/14,,4.35.94.0/26,2001:1900:2100:14::/64,native,Level3
-LGA06,US,NY,New York,Equinix,10/21/14,,128.177.119.192/26,2001:438:fffd:2b::/64,native,Zayo
-LGA07,US,NY,New York,Google,,,66.151.223.128/26,2600:c0f:2002::/64,,Internap
-LHR01,UK,,London,Google,06/04/09,,217.163.1.64/26,2001:4C08:2003:3::/64,native,Level3
-LJU01,SI,,Ljubljana,go6,08/03/12,,91.239.96.64/26,2001:67c:27e4:100::/64,native?,go6
-LOS01,NG,,Lagos,Nigeria IXP,1/15/2015,,196.216.149.64/26,,,Nigeria IXP
-MAD01,ES,,Madrid,Google,,,213.200.103.128/26,2001:0668:001F:0016::/64,native,Tinet
-MIA01,US,FL,Miami,Google,05/28/09,,4.71.210.192/26,2001:1900:3001:A::/64,native,Level3
-MIA02,US,FL,Miami,Terremark,11/10/2014,,38.109.21.0/26,2001:550:6C01::/64,native,Cogent
-MIA03,US,FL,Miami,Terremark,11/10/2014,,66.110.73.0/26,2001:5a0:3801::/64,native,Tata
-MIA04,US,FL,Miami,Terremark,11/10/2014,,173.205.3.128/26,2001:0668:001F:001F::/64,native,GTT
-MIA05,US,FL,Miami,Terremark,11/10/2014,,128.177.109.0/26,2001:438:FFFD:29::/64,native,Zayo
-MIL01,IT,,Milan,Google,,, 213.200.99.192/26,2001:0668:001F:0017::/64,native,Tinet
-MNL01,PH,,Quezon City,PHOpenIX,,,202.90.156.0/26,2001:d18:0:35::/64,native,PHOpenIX
-NBO01,KE,,Nairobi,KENET,2/13/2013,,197.136.0.64/26,2C0F:FE08:13:64::/64,native,ubuntunet
-NUQ01,US,CA,Mountain View,Google,01/28/09,01/01/15,64.9.225.128/26,2604:ca00:f000::/64,native,Google
-NUQ02,US,CA,Redwood,ISC,10/26/2012,, 149.20.5.64/26,2001:4F8:1:1001::/64,native,ISC
-NUQ03,US,CA,San Jose,Equinix,10/1/2014,,38.102.163.128/26,2001:550:1502::/64,native,Cogent
-NUQ04,US,CA,San Jose,Equinix,09/25/14,,66.110.32.64/26,2001:5a0:3e00::/64,native,Tata
-NUQ05,US,CA,San Jose,Equinix,01/01/16,,216.156.85.192/26,2610:0018:0111:0007::/64,native,XO
-NUQ06,US,CA,San Jose,Equinix,10/1/2014,,128.177.109.128/26,2001:438:fffd:2d::/64,native,Zayo
-ORD01,US,IL,Chicago,Google,03/20/09,,4.71.251.128/26,2001:1900:3001:B::/64,native,Level3
-ORD02,US,IL,Chicago,Equinix,10/1/2014,,38.65.210.192/26,2001:550:1B01:1::/64,native,Cogent
-ORD03,US,IL,Chicago,Equinix,10/1/2014,,66.198.24.64/26,2001:5a0:4400::/64,native,Tata
-ORD04,US,IL,Chicago,Equinix,09/25/14,,173.205.3.192/26,2001:0668:001F:0020::/64,native,GTT
-ORD05,US,IL,Chicago,Equinix,10/1/2014,,128.177.163.0/26,2001:438:fffd:2f::/64,native,Zayo
-PAR01,FR,,Paris,Google,07/09/09,,80.239.168.192/26,2001:2030:0000:001A::/64,native,Telia
-PRG01,CZ,,Prague,Google,12/5/2012,,212.162.51.64/26 ,2001:4c08:2003:4::/64,native,Level3
-SEA01,US,WA,Seattle,Google,03/13/09,,38.102.0.64/26,2001:550:3200:1::/64 ,native,Cogent
-SEA02,US,WA,Seattle,Equinix,09/25/14,,63.243.224.0/26,2001:5a0:4400::/64,native,Tata
-SEA03,US,WA,Seattle,Equinix,09/25/14,,173.205.3.0/26,2001:0668:001F:001D::/64,native,GTT
-SEA04,US,WA,Seattle,Equinix,01/05/15,,4.71.157.128/26,2001:1900:2100:16::/64,native,Level3
-SEA05,US,WA,Seattle,Equinix,01/01/16,,64.3.225.64/26,2610:0018:0114:4001::/64,native,XO
-SIN01,SG,,Changi,Google,1/30/2014,,180.87.97.64/26,2405:2000:301::/64,,Tata
-SVG01,NO,,Sola,Altibox,,,81.167.39.0/26,2a01:798:0:13::/64,native,Altibox
-SYD01,AU,,Sydney,AARNET,05/05/10,,203.5.76.128/26,2001:388:00d0::/64,native,AARNET
-SYD02,AU,,Sydney,Vocus,5/14/2012,,175.45.79.0/26,2402:7800:0:12::/64,native,Vocus
-TNR01,MG,,Antananarivo,Telecom Malagasy,4/14/2016,,41.188.12.64/26,,,Telecom Malagasy
-TPE01,TW,,Taipei,,5/29/2012,,163.22.28.0/26,2001:e10:6840:28::/64,native,National Chi Nan University
-TRN01,IT,,Turin,Topix,2/3/2012,,194.116.85.192/26,2001:7F8:23:307::/64,native,Topix
-TUN01,TN,,Tunis,ATI,4/24/2013,,41.231.21.0/26,2c0f:fab0:ffff:1000::/64,native,ATI
-VIE01,AT,,Vienna,RTR,5/10/2012,,213.208.152.0/26,2a01:190:1700:38::/64,,RTR
-WLG01,NZ,,Wellington,Victoria University of Wellington,09/13/11,1/1/2016,103.10.233.0/26,2404:2000:3000::/64,native,Victoria University of Wellington
-WLG02,NZ,,Wellington,Victoria University of Wellington,01/01/16,,163.7.129.64/26,2404:138:4009:1::/64,native,Victoria University of Wellington
-YUL01,CA,,Montreal,CIRA,,,162.219.49.0/26,2620:10a:80fe::/48,native,Hurricane Electric
-YYC01,CA,,Calgary,CIRA,9/1/2014,,162.219.50.0/26,2620:10a:80ff::/48,native,Hurricane Electric
-YYZ01,CA,,Toronto,CIRA,,,162.219.48.0/26,2620:10a:80fd::/48,native,Hurricane Electric
+Internap",02/10/09,04/21/16,74.63.50.0/26,2001:48c8:5:f::/64,,Voxel,North America,LGA01
+LGA02,US,NY,New York,Google,06/08/09,,38.106.70.128/26, 2001:550:1D00:100::/64 ,native,Cogent,North America,LGA02
+LGA03,US,NY,New York,Equinix,05/05/15,,64.86.148.128/26,2001:5a0:4300::/64,native,Tata,North America,LGA03
+LGA04,US,NY,New York,Equinix,09/25/14,,173.205.4.64/26,2001:0668:001F:0022::/64,native,GTT,North America,LGA04
+LGA05,US,NY,New York,Equinix,11/14/14,,4.35.94.0/26,2001:1900:2100:14::/64,native,Level3,North America,LGA05
+LGA06,US,NY,New York,Equinix,10/21/14,,128.177.119.192/26,2001:438:fffd:2b::/64,native,Zayo,North America,LGA06
+LGA07,US,NY,New York,Google,,,66.151.223.128/26,2600:c0f:2002::/64,,Internap,North America,LGA07
+LHR01,UK,,London,Google,06/04/09,,217.163.1.64/26,2001:4C08:2003:3::/64,native,Level3,Europe,LHR01
+LJU01,SI,,Ljubljana,go6,08/03/12,,91.239.96.64/26,2001:67c:27e4:100::/64,native?,go6,Europe,LJU01
+LOS01,NG,,Lagos,Nigeria IXP,1/15/2015,,196.216.149.64/26,,,Nigeria IXP,Africa,LOS01
+MAD01,ES,,Madrid,Google,,,213.200.103.128/26,2001:0668:001F:0016::/64,native,Tinet,Europe,MAD01
+MIA01,US,FL,Miami,Google,05/28/09,,4.71.210.192/26,2001:1900:3001:A::/64,native,Level3,North America,MIA01
+MIA02,US,FL,Miami,Terremark,11/10/2014,,38.109.21.0/26,2001:550:6C01::/64,native,Cogent,North America,MIA02
+MIA03,US,FL,Miami,Terremark,11/10/2014,,66.110.73.0/26,2001:5a0:3801::/64,native,Tata,North America,MIA03
+MIA04,US,FL,Miami,Terremark,11/10/2014,,173.205.3.128/26,2001:0668:001F:001F::/64,native,GTT,North America,MIA04
+MIA05,US,FL,Miami,Terremark,11/10/2014,,128.177.109.0/26,2001:438:FFFD:29::/64,native,Zayo,North America,MIA05
+MIL01,IT,,Milan,Google,,, 213.200.99.192/26,2001:0668:001F:0017::/64,native,Tinet,Europe,MIL01
+MNL01,PH,,Quezon City,PHOpenIX,,,202.90.156.0/26,2001:d18:0:35::/64,native,PHOpenIX,Asia,MNL01
+NBO01,KE,,Nairobi,KENET,2/13/2013,,197.136.0.64/26,2C0F:FE08:13:64::/64,native,ubuntunet,Africa,NBO01
+NUQ01,US,CA,Mountain View,Google,01/28/09,01/01/15,64.9.225.128/26,2604:ca00:f000::/64,native,Google,North America,NUQ01
+NUQ02,US,CA,Redwood,ISC,10/26/2012,, 149.20.5.64/26,2001:4F8:1:1001::/64,native,ISC,North America,NUQ02
+NUQ03,US,CA,San Jose,Equinix,10/1/2014,,38.102.163.128/26,2001:550:1502::/64,native,Cogent,North America,NUQ03
+NUQ04,US,CA,San Jose,Equinix,09/25/14,,66.110.32.64/26,2001:5a0:3e00::/64,native,Tata,North America,NUQ04
+NUQ05,US,CA,San Jose,Equinix,01/01/16,,216.156.85.192/26,2610:0018:0111:0007::/64,native,XO,North America,NUQ05
+NUQ06,US,CA,San Jose,Equinix,10/1/2014,,128.177.109.128/26,2001:438:fffd:2d::/64,native,Zayo,North America,NUQ06
+ORD01,US,IL,Chicago,Google,03/20/09,,4.71.251.128/26,2001:1900:3001:B::/64,native,Level3,North America,ORD01
+ORD02,US,IL,Chicago,Equinix,10/1/2014,,38.65.210.192/26,2001:550:1B01:1::/64,native,Cogent,North America,ORD02
+ORD03,US,IL,Chicago,Equinix,10/1/2014,,66.198.24.64/26,2001:5a0:4400::/64,native,Tata,North America,ORD03
+ORD04,US,IL,Chicago,Equinix,09/25/14,,173.205.3.192/26,2001:0668:001F:0020::/64,native,GTT,North America,ORD04
+ORD05,US,IL,Chicago,Equinix,10/1/2014,,128.177.163.0/26,2001:438:fffd:2f::/64,native,Zayo,North America,ORD05
+PAR01,FR,,Paris,Google,07/09/09,,80.239.168.192/26,2001:2030:0000:001A::/64,native,Telia,Europe,PAR01
+PRG01,CZ,,Prague,Google,12/5/2012,,212.162.51.64/26 ,2001:4c08:2003:4::/64,native,Level3,Europe,PRG01
+SEA01,US,WA,Seattle,Google,03/13/09,,38.102.0.64/26,2001:550:3200:1::/64 ,native,Cogent,North America,SEA01
+SEA02,US,WA,Seattle,Equinix,09/25/14,,63.243.224.0/26,2001:5a0:4400::/64,native,Tata,North America,SEA02
+SEA03,US,WA,Seattle,Equinix,09/25/14,,173.205.3.0/26,2001:0668:001F:001D::/64,native,GTT,North America,SEA03
+SEA04,US,WA,Seattle,Equinix,01/05/15,,4.71.157.128/26,2001:1900:2100:16::/64,native,Level3,North America,SEA04
+SEA05,US,WA,Seattle,Equinix,01/01/16,,64.3.225.64/26,2610:0018:0114:4001::/64,native,XO,North America,SEA05
+SIN01,SG,,Changi,Google,1/30/2014,,180.87.97.64/26,2405:2000:301::/64,,Tata,Asia,SIN01
+SVG01,NO,,Sola,Altibox,,,81.167.39.0/26,2a01:798:0:13::/64,native,Altibox,Europe,SVG01
+SYD01,AU,,Sydney,AARNET,05/05/10,,203.5.76.128/26,2001:388:00d0::/64,native,AARNET,Oceania,SYD01
+SYD02,AU,,Sydney,Vocus,5/14/2012,,175.45.79.0/26,2402:7800:0:12::/64,native,Vocus,Oceania,SYD02
+TNR01,MG,,Antananarivo,Telecom Malagasy,4/14/2016,,41.188.12.64/26,,,Telecom Malagasy,Africa,TNR01
+TPE01,TW,,Taipei,,5/29/2012,,163.22.28.0/26,2001:e10:6840:28::/64,native,National Chi Nan University,Asia,TPE01
+TRN01,IT,,Turin,Topix,2/3/2012,,194.116.85.192/26,2001:7F8:23:307::/64,native,Topix,Europe,TRN01
+TUN01,TN,,Tunis,ATI,4/24/2013,,41.231.21.0/26,2c0f:fab0:ffff:1000::/64,native,ATI,Africa,TUN01
+VIE01,AT,,Vienna,RTR,5/10/2012,,213.208.152.0/26,2a01:190:1700:38::/64,,RTR,Europe,VIE01
+WLG01,NZ,,Wellington,Victoria University of Wellington,09/13/11,1/1/2016,103.10.233.0/26,2404:2000:3000::/64,native,Victoria University of Wellington,Oceania,WLG01
+WLG02,NZ,,Wellington,Victoria University of Wellington,01/01/16,,163.7.129.64/26,2404:138:4009:1::/64,native,Victoria University of Wellington,Oceania,WLG02
+YUL01,CA,,Montreal,CIRA,,,162.219.49.0/26,2620:10a:80fe::/48,native,Hurricane Electric,North America,YUL01
+YYC01,CA,,Calgary,CIRA,9/1/2014,,162.219.50.0/26,2620:10a:80ff::/48,native,Hurricane Electric,North America,YYC01
+YYZ01,CA,,Toronto,CIRA,,,162.219.48.0/26,2620:10a:80fd::/48,native,Hurricane Electric,North America,YYZ01


### PR DESCRIPTION
This PR adds the column 'Region' back into the sites spreadsheet because the Pipeline does use it. The previous commit on this file inadvertently removed the column. @iros PTAL?